### PR TITLE
Fix the load_resources function for Linux. Add .gitignore for Python.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,128 @@
+
+# Created by https://www.gitignore.io/api/python
+
+### Python ###
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+
+### Python Patch ###
+.venv/
+
+### Python.VirtualEnv Stack ###
+# Virtualenv
+# http://iamzed.com/2009/05/07/a-primer-on-virtualenv/
+[Bb]in
+[Ii]nclude
+[Ll]ib
+[Ll]ib64
+[Ll]ocal
+[Ss]cripts
+pyvenv.cfg
+pip-selfcheck.json
+
+
+# End of https://www.gitignore.io/api/python
+
+# Generated using ignr.py - github.com/Antrikshy/ignr.py

--- a/AAB.py
+++ b/AAB.py
@@ -7,7 +7,7 @@ import os
 import random as rd
 import tkinter as tk
 #import winsound as ws
-
+from pathlib import Path
 
 
 class AAB:
@@ -353,18 +353,15 @@ class AAB:
 	
 	
 	def load_resources(self, *args):
-		floc = "resources\\"  # file location of the Gif images
-		fdata = os.listdir(floc)  # get all files in the directory
-		# separate GIFs from the rest and gives the filename location
-		glist = [data[:-4] for data in fdata if data[-4:] == ".gif"]  # Gif
-		llist = [floc + data for data in fdata if data[-4:] == ".gif"]  # path
+		floc = Path("resources")  # file location of the images
+		gif_list = list(floc.glob("*.gif")) # find GIFs
+		png_list = list(floc.glob("*.png")) # find PNGs
+		img_list = gif_list + png_list
+		img_name = [img.stem for img in img_list] # find the file names without extensions
+		
 		self.rsc = {}
-		for gif in range(len(glist)):
-			self.rsc[glist[gif]] = tk.PhotoImage(file = llist[gif])
-		glist2 = [data[:-4] for data in fdata if data[-4:] == ".png"]  # Gif
-		llist2 = [floc + data for data in fdata if data[-4:] == ".png"]  # path	
-		for gif2 in range(len(glist2)):
-			self.rsc[glist2[gif2]] = tk.PhotoImage(file = llist2[gif2])
+		for index, img in enumerate(img_name):
+			self.rsc[img] = tk.PhotoImage(file=img_list[index])
 			
 	
 	def load_variables(self, *args):


### PR DESCRIPTION
It didn't work on Linux, because it used Window's path syntax. To
fix this, pathlib from the standard library was used. Furthermore,
the load_resources function was cleaned up, made simpler, and easier
to understand.

Adding a .gitigignore for common python files is also important.